### PR TITLE
Use format instead of literal string interpolation

### DIFF
--- a/emqtt.py
+++ b/emqtt.py
@@ -72,6 +72,6 @@ def run():
 
 
 if __name__ == '__main__':
-    log.debug(', '.join([f'{k}={v}' for k, v in config.items()]))
+    log.debug(', '.join(['{k}={v}'.format(k=k, v=v) for k, v in config.items()]))
     log.info('Running')
     run()


### PR DESCRIPTION
This is to support older versions of python3 since f'string' requires python >=3.6